### PR TITLE
feat: update Spotify credentials handling and improve environment 

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,9 +22,9 @@ console.log('📋 Variabili d\'ambiente:');
 console.log(`   - NODE_ENV: ${nodeEnv}`);
 console.log(`   - VERCEL_ENV: ${process.env.VERCEL_ENV || 'non impostato'}`);
 console.log('🎵 Credenziali Spotify:');
-console.log(`   - CLIENT_ID: ${process.env.CLIENT_ID ? '✓ impostato' : '❌ mancante'} (${process.env.CLIENT_ID ? process.env.CLIENT_ID.substring(0, 5) + '...' : 'undefined'})`);
-console.log(`   - CLIENT_SECRET: ${process.env.CLIENT_SECRET ? '✓ impostato' : '❌ mancante'}`);
-console.log(`   - REDIRECT_URI: ${process.env.REDIRECT_URI || 'non impostato'}`);
+console.log(`   - CLIENT_ID: ${process.env.SPOTIFY_CLIENT_ID ? '✓ impostato' : '❌ mancante'} (${process.env.CLIENT_ID ? process.env.CLIENT_ID.substring(0, 5) + '...' : 'undefined'})`);
+console.log(`   - CLIENT_SECRET: ${process.env.SPOTIFY_CLIENT_SECRET ? '✓ impostato' : '❌ mancante'}`);
+console.log(`   - REDIRECT_URI: ${process.env.SPOTIFY_REDIRECT_URI || 'non impostato'}`);
 console.log('-------------------------------------');
 
 // Configure express to use EJS as the view engine


### PR DESCRIPTION
This pull request includes changes to improve the handling of environment variables and enhance the logging for the Spotify service configuration. The most important changes are focused on ensuring the correct environment variables are used and providing better feedback during the initialization of the Spotify service.

Improvements to environment variable handling:

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L25-R27): Updated the environment variable names for Spotify credentials to use `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, and `SPOTIFY_REDIRECT_URI` instead of the previous names.
* [`services/spotify.js`](diffhunk://#diff-cf216cbd245793907bf93e5258cb20ded43f413161b0670037afed158da104ceR6-R39): Added conditional loading of environment variables from `.env.local` in development mode and provided fallback values for `CLIENT_ID`, `CLIENT_SECRET`, and `REDIRECT_URI` if they are not set.

Enhancements to logging and error handling:

* [`services/spotify.js`](diffhunk://#diff-cf216cbd245793907bf93e5258cb20ded43f413161b0670037afed158da104ceR6-R39): Enhanced the logging to display whether the Spotify credentials are set and provided warnings if any of the critical environment variables are missing.
* [`services/spotify.js`](diffhunk://#diff-cf216cbd245793907bf93e5258cb20ded43f413161b0670037afed158da104ceL40-R61): Improved error handling by throwing a detailed error message if `CLIENT_ID` is not configured, including instructions for setting it up in Vercel or `.env.local` for development.